### PR TITLE
[WIP] fix deprecation cop whining

### DIFF
--- a/lib/refactor.coffee
+++ b/lib/refactor.coffee
@@ -22,8 +22,8 @@ new class Main
     @watchers = []
 
     atom.workspaceView.eachEditorView @onCreated
-    atom.workspaceView.command @renameCommand, @onRename
-    atom.workspaceView.command @doneCommand, @onDone
+    atom.commands.add 'atom-editor', @renameCommand, @onRename
+    atom.commands.add 'atom-editor', @doneCommand, @onDone
 
   deactivate: ->
     @moduleManager.destruct()


### PR DESCRIPTION
As noted by a few issues (#13 #12) generated by deprecation-cop (kind of an annoying behavior that it has, tbh) the workspaceview is deprecated and generally not needed. By extension we can get rid of the editor view as well with some simple refactoring.

Yes, pun intended.
